### PR TITLE
multi layer dockerfile with caching

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -6,6 +6,7 @@ on:
           - main
     workflow_dispatch:
 env:
+    IMAGE_NAME: ask-js
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:
@@ -16,92 +17,63 @@ jobs:
             contents: read
             packages: write
             id-token: write
-        strategy:
-            fail-fast: false
-            matrix:
-              platform:
-                - linux/amd64
-                - linux/arm64
 
         steps:
-            - name: Preparation
-              run: |
-                platform=${{ matrix.platform }}
-                echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
             - name: Checkout Push to Registry action
               uses: actions/checkout@v4
+              with:
+                fetch-depth: 1
 
-            - name: Gather environment variables
-              run: echo "IMAGE_NAME=ask-js" >> $GITHUB_ENV
+            - uses: sigstore/cosign-installer@v3.8.1
+              if: github.event_name != 'pull_request'
+
+            - name: Set up Docker Buildx
+              id: buildx
+              uses: docker/setup-buildx-action@v3.0.0
+              with:
+                platforms: linux/amd64,linux/arm64
 
             - name: Image Metadata
               uses: docker/metadata-action@v5
               id: meta
               with:
                   images: |
-                      ${{ env.IMAGE_NAME }}
+                      ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
                   labels: |
                       org.opencontainers.image.title=${{ env.IMAGE_NAME }}
                       org.opencontainers.image.description=multiuser ask software
-
-            - name: Generate tags
-              id: generate-tags
-              shell: bash
-              run: |
-                  # Generate a timestamp for creating an image version history
-                  TIMESTAMP="$(date +%Y%m%d)"
-                  COMMIT_TAGS=()
-                  BUILD_TAGS=()
-                  # Have tags for tracking builds during pull request
-                  SHA_SHORT="${GITHUB_SHA::7}"
-                  COMMIT_TAGS+=("pr-${{ github.event.number }}")
-                  COMMIT_TAGS+=("${SHA_SHORT}")
-
-                  BUILD_TAGS+=("${TIMESTAMP}")
-                  BUILD_TAGS+=("dev")
-
-                  if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-                      echo "Generated the following commit tags: "
-                      for TAG in "${COMMIT_TAGS[@]}"; do
-                          echo "${TAG}"
-                      done
-                      alias_tags=("${COMMIT_TAGS[@]}")
-                  else
-                      alias_tags=("${BUILD_TAGS[@]}")
-                  fi
-                  echo "Generated the following build tags: "
-                  for TAG in "${BUILD_TAGS[@]}"; do
-                      echo "${TAG}"
-                  done
-                  echo "alias_tags=${alias_tags[*]}" >> $GITHUB_OUTPUT
-
-            - name: Build Image
-              id: build_image
-              uses: redhat-actions/buildah-build@v2
-              with:
-                  containerfiles: "Dockerfile"
-                  image: ${{ env.IMAGE_NAME }}
                   tags: |
-                      ${{ steps.generate-tags.outputs.alias_tags }}
-                  labels: ${{ steps.meta.outputs.labels }}
-                  oci: false
+                      type=sha
+                      type=ref,event=pr
+                      type=raw,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},value=dev
+                  # https://github.com/docker/metadata-action/issues/84
 
-            - name: Push To GHCR
-              uses: redhat-actions/push-to-registry@v2
-              id: push
-              if: github.event_name != 'pull_request'
-              env:
-                  REGISTRY_USER: ${{ github.actor }}
-                  REGISTRY_PASSWORD: ${{ github.token }}
+            - name: Setup cache
+              uses: actions/cache@v3
+              id: cache
               with:
-                  image: ${{ steps.build_image.outputs.image }}
-                  tags: ${{ steps.build_image.outputs.tags }}
-                  registry: ${{ env.IMAGE_REGISTRY }}
-                  username: ${{ env.REGISTRY_USER }}
-                  password: ${{ env.REGISTRY_PASSWORD }}
-                  extra-args: |
-                      --disable-content-trust
+                  path: |
+                    var-cache
+                    root-npm
+                    app-pnpm
+                    app-modules
+                    app-backend-modules
+                    app-frontend-modules
+                  key: cache-${{ hashFiles('Dockerfile') }}
+
+            - name: Inject cache into Docker
+              uses: reproducible-containers/buildkit-cache-dance@v3
+              with:
+                cache-map: |
+                    {
+                    "var-cache": "/var/cache",
+                    "root-npm": "/root/.npm",
+                    "app-pnpm": "/app/.local/share/pnpm",
+                    "app-modules": "/app/node_modules",
+                    "app-backend-modules": "/app/packages/backend/node_modules",
+                    "app-frontend-modules": "/app/packages/frontend/node_modules"
+                    }
+                skip-extraction: ${{ steps.cache.outputs.cache-hit }}
 
             - name: Login to GitHub Container Registry
               uses: docker/login-action@v3
@@ -111,19 +83,28 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
-            - uses: sigstore/cosign-installer@v3.8.1
-              if: github.event_name != 'pull_request'
+            - name: Build and Push to GHCR
+              id: build
+              uses: docker/build-push-action@v5
+              with:
+                builder: ${{ steps.buildx.outputs.name }}
+                context: .
+                push: ${{ github.event_name != 'pull_request' }}
+                platforms: ${{ steps.buildx.outputs.platforms }}
+                tags: ${{ steps.meta.outputs.tags }}
+                labels: ${{ steps.meta.outputs.labels }}
+                cache-from: type=gha
+                cache-to: type=gha,mode=max
 
             - name: Sign container image
               if: github.event_name != 'pull_request'
               run: |
-                  cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}@${TAGS}
+                images=""
+                for tag in ${TAGS}; do
+                    images+="${tag}@${DIGEST} "
+                done
+                cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${images}
               env:
-                  TAGS: ${{ steps.push.outputs.digest }}
-                  COSIGN_EXPERIMENTAL: false
-                  COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-
-            - name: Echo outputs
-              if: github.event_name != 'pull_request'
-              run: |
-                  echo "${{ toJSON(steps.push.outputs) }}"
+                DIGEST: ${{ steps.build.outputs.digest }}
+                TAGS: ${{ steps.meta.outputs.tags }}
+                COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,88 @@
-FROM node:23-slim
+# syntax = docker.io/docker/dockerfile:1
 
-WORKDIR /ask-js
-COPY . .
+ARG node=22
+ARG alpine=3.21
 
-RUN npm install -g pnpm@latest-10 && \
-        pnpm i && pnpm build
+FROM docker.io/library/node:${node}-alpine${alpine} AS web-base
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk -U upgrade \
+ && adduser -h /app -u 1001 -k /dev/null -D app \
+ && chown app:app /app
 
-CMD ["/bin/bash", "-c", "pnpm migration:apply && pnpm start"]
+WORKDIR /app
+COPY --chown=1001:1001 ./packages/backend/package.json /app/packages/backend/
+COPY --chown=1001:1001 ./package.json /app/
+
+
+FROM web-base AS web-pnpm
+ENV CI=1
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g pnpm@latest-10
+
+COPY --chown=1001:1001 ./pnpm-workspace.yaml /app/
+COPY --chown=1001:1001 ./packages/frontend/package.json /app/packages/frontend/
+COPY --chown=1001:1001 ./packages/backend/pnpm-lock.yaml /app/packages/backend/
+COPY --chown=1001:1001 ./packages/frontend/pnpm-lock.yaml /app/packages/frontend/
+COPY --chown=1001:1001 ./pnpm-lock.yaml /app/
+
+USER app:app
+
+
+FROM web-pnpm AS web-deps
+RUN --mount=type=cache,target=/app/.local/share/pnpm,uid=1001,gid=1001,sharing=locked \
+    pnpm install --prod
+
+
+FROM web-pnpm AS web-build-base
+RUN --mount=type=cache,target=/app/.local/share/pnpm,uid=1001,gid=1001,sharing=locked \
+    --mount=type=cache,target=/app/node_modules,uid=1001,gid=1001 \
+    --mount=type=cache,target=/app/packages/backend/node_modules,uid=1001,gid=1001 \
+    --mount=type=cache,target=/app/packages/frontend/node_modules,uid=1001,gid=1001 \
+    pnpm install
+
+
+FROM web-build-base AS web-build-backend
+WORKDIR /app/packages/backend
+
+COPY --chown=1001:1001 ./packages/backend/.swcrc /app/packages/backend/
+COPY --chown=1001:1001 ./packages/backend/tsconfig.json /app/packages/backend/
+
+COPY --chown=1001:1001 ./packages/backend/src /app/packages/backend/src/
+
+RUN --mount=type=cache,target=/app/.local/share/pnpm,uid=1001,gid=1001 \
+    --mount=type=cache,target=/app/node_modules,uid=1001,gid=1001 \
+    --mount=type=cache,target=/app/packages/backend/node_modules,uid=1001,gid=1001 \
+    pnpm run build
+
+
+FROM web-build-base AS web-build-frontend
+WORKDIR /app/packages/frontend
+
+COPY --chown=1001:1001 ./packages/frontend/svelte.config.js /app/packages/frontend/
+COPY --chown=1001:1001 ./packages/frontend/vite.config.js /app/packages/frontend/
+COPY --chown=1001:1001 ./packages/frontend/vite-plugin-optimize-tabler.ts /app/packages/frontend/
+COPY --chown=1001:1001 ./packages/frontend/jsconfig.json /app/packages/frontend/
+
+COPY --chown=1001:1001 ./packages/frontend/static /app/packages/frontend/static/
+COPY --chown=1001:1001 ./packages/frontend/src /app/packages/frontend/src/
+
+RUN --mount=type=cache,target=/app/.local/share/pnpm,uid=1001,gid=1001 \
+    --mount=type=cache,target=/app/node_modules,uid=1001,gid=1001 \
+    --mount=type=cache,target=/app/packages/frontend/node_modules,uid=1001,gid=1001 \
+    pnpm run build
+
+
+FROM web-base
+CMD ["/bin/sh", "-c", "cd /app/packages/backend && npm run migrate && npm run start"]
+
+RUN mkdir -p /app/packages/backend /app/packages/frontend
+
+COPY --from=web-deps /app/node_modules /app/node_modules
+COPY --from=web-deps /app/packages/backend/node_modules /app/packages/backend/node_modules
+# uncomment when frontend('s node part) gets non-dev dependencies
+#COPY --from=web-deps /app/packages/frontend/node_modules /app/packages/frontend/node_modules
+COPY --from=web-build-backend /app/packages/backend/built /app/packages/backend/built
+COPY --from=web-build-frontend /app/packages/frontend/build /app/packages/frontend/build
+
+USER app:app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG node=22
 ARG alpine=3.21
 
 FROM docker.io/library/node:${node}-alpine${alpine} AS web-base
-RUN --mount=type=cache,target=/var/cache/apk \
+RUN --mount=type=cache,target=/var/cache \
     apk -U upgrade \
  && adduser -h /app -u 1001 -k /dev/null -D app \
  && chown app:app /app

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -13,7 +13,7 @@ services:
             # wget -O config.json https://raw.githubusercontent.com/ihateblueb/ask-js/refs/heads/main/config/config.example.json
             #
             # this file *must* also be modified to replace "host" under "db" with "db", any other changes are of personal preference
-            - ./config.json:/ask-js/config/config.json
+            - ./config.json:/app/config/config.json
 
     db:
         restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -24,10 +24,7 @@
 	"devDependencies": {
 		"npm-run-all": "^4.1.5",
 		"prettier": "^3.5.3",
+		"prettier-plugin-svelte": "^3.3.3",
 		"typescript": "^5.8.2"
-	},
-	"dependencies": {
-		"backend": "^0.0.0",
-		"prettier-plugin-svelte": "^3.3.3"
 	}
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,9 +9,9 @@
 		"start-dev": "node --watch --watch-preserve-output built/main.js",
 		"build": "swc src -d built --strip-leading-paths",
 		"build-dev": "swc src -d built --strip-leading-paths --watch",
-		"migrate": "pnpm exec typeorm migration:run -d ./built/utils/db.js",
-		"generateMigration": "pnpm build && pnpm exec typeorm migration:generate ./src/migrations/migration -d ./built/utils/db.js",
-		"revert": "pnpm exec typeorm migration:revert -d ./built/utils/db.js"
+		"migrate": "typeorm migration:run -d ./built/utils/db.js",
+		"generateMigration": "pnpm build && typeorm migration:generate ./src/migrations/migration -d ./built/utils/db.js",
+		"revert": "typeorm migration:revert -d ./built/utils/db.js"
 	},
 	"dependencies": {
 		"@fastify/auth": "^5.0.2",
@@ -27,11 +27,8 @@
 		"fastify-plugin": "^5.0.1",
 		"frontend": "workspace:frontend",
 		"jsdom": "^26.0.0",
-		"mfm-js": "^0.24.0",
-		"npm-run-all": "^4.1.5",
 		"pg": "^8.13.3",
-		"typeorm": "^0.3.20",
-		"vite": "^6.1.1"
+		"typeorm": "^0.3.20"
 	},
 	"devDependencies": {
 		"@swc/cli": "^0.6.0",
@@ -39,7 +36,6 @@
 		"@types/bcryptjs": "^2.4.6",
 		"@types/jsdom": "^21.1.7",
 		"chokidar": "^4.0.3",
-		"json-schema-to-ts": "^3.1.1",
-		"typescript": "^5.7.3"
+		"json-schema-to-ts": "^3.1.1"
 	}
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,17 +13,16 @@
 		"@sveltejs/adapter-node": "^5.2.12",
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
+		"sass": "^1.83.0",
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"svelte-preprocess": "^6.0.3",
 		"typescript": "^5.0.0",
-		"vite": "^6.0.0"
-	},
-	"dependencies": {
+		"vite": "^6.0.0",
 		"@tabler/icons-svelte": "^3.30.0",
 		"@tanstack/svelte-query": "^5.66.9",
-		"magic-string": "^0.30.17",
-		"sass": "^1.83.0",
-		"uuid": "^11.0.4"
+		"magic-string": "^0.30.17"
+	},
+	"dependencies": {
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      backend:
-        specifier: ^0.0.0
-        version: 0.0.0
-      prettier-plugin-svelte:
-        specifier: ^3.3.3
-        version: 3.3.3(prettier@3.5.3)(svelte@5.20.2)
     devDependencies:
       npm-run-all:
         specifier: ^4.1.5
@@ -21,6 +14,9 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
+      prettier-plugin-svelte:
+        specifier: ^3.3.3
+        version: 3.3.3(prettier@3.5.3)(svelte@5.20.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -66,21 +62,12 @@ importers:
       jsdom:
         specifier: ^26.0.0
         version: 26.0.0
-      mfm-js:
-        specifier: ^0.24.0
-        version: 0.24.0
-      npm-run-all:
-        specifier: ^4.1.5
-        version: 4.1.5
       pg:
         specifier: ^8.13.3
         version: 8.13.3
       typeorm:
         specifier: ^0.3.20
         version: 0.3.20(pg@8.13.3)
-      vite:
-        specifier: ^6.1.1
-        version: 6.1.1(@types/node@22.13.4)(sass@1.85.0)(yaml@2.7.0)
     devDependencies:
       '@swc/cli':
         specifier: ^0.6.0
@@ -100,27 +87,8 @@ importers:
       json-schema-to-ts:
         specifier: ^3.1.1
         version: 3.1.1
-      typescript:
-        specifier: ^5.7.3
-        version: 5.7.3
 
   packages/frontend:
-    dependencies:
-      '@tabler/icons-svelte':
-        specifier: ^3.30.0
-        version: 3.30.0(svelte@5.20.2)
-      '@tanstack/svelte-query':
-        specifier: ^5.66.9
-        version: 5.66.9(svelte@5.20.2)
-      magic-string:
-        specifier: ^0.30.17
-        version: 0.30.17
-      sass:
-        specifier: ^1.83.0
-        version: 1.85.0
-      uuid:
-        specifier: ^11.0.4
-        version: 11.1.0
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^4.0.0
@@ -134,6 +102,18 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
         version: 5.0.3(svelte@5.20.2)(vite@6.1.1(@types/node@22.13.4)(sass@1.85.0)(yaml@2.7.0))
+      '@tabler/icons-svelte':
+        specifier: ^3.30.0
+        version: 3.30.0(svelte@5.20.2)
+      '@tanstack/svelte-query':
+        specifier: ^5.66.9
+        version: 5.66.9(svelte@5.20.2)
+      magic-string:
+        specifier: ^0.30.17
+        version: 0.30.17
+      sass:
+        specifier: ^1.83.0
+        version: 1.85.0
       svelte:
         specifier: ^5.0.0
         version: 5.20.2
@@ -900,9 +880,6 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@twemoji/parser@15.0.0':
-    resolution: {integrity: sha512-lh9515BNsvKSNvyUqbj5yFu83iIDQ77SwVcsN/SnEGawczhsKU6qWuogewN1GweTi5Imo5ToQ9s+nNTf97IXvg==}
-
   '@types/bcryptjs@2.4.6':
     resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
 
@@ -1067,9 +1044,6 @@ packages:
 
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
-
-  backend@0.0.0:
-    resolution: {integrity: sha512-Fq2aG5+zmmsKv2Dhm3ijAU5spnKOb5ldJlnnC/Vhk6n8In6zaq9eCPBMRiz2j94P/r84QEaBmtwh9tjaDPiQqg==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1822,9 +1796,6 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-
-  mfm-js@0.24.0:
-    resolution: {integrity: sha512-6m8N0ElH9/4CA1izhVqmxTfLj5Z9RspdqM/lMew4xU/UTgm4Pf//VpDunpasxbRFjeJSVW+zoVwL4ZPfPtfiQg==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2618,10 +2589,6 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
@@ -3382,8 +3349,6 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@twemoji/parser@15.0.0': {}
-
   '@types/bcryptjs@2.4.6': {}
 
   '@types/cookie@0.6.0': {}
@@ -3558,8 +3523,6 @@ snapshots:
   axobject-query@4.1.0: {}
 
   b4a@1.6.7: {}
-
-  backend@0.0.0: {}
 
   balanced-match@1.0.2: {}
 
@@ -4449,10 +4412,6 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mfm-js@0.24.0:
-    dependencies:
-      '@twemoji/parser': 15.0.0
-
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -5219,8 +5178,6 @@ snapshots:
       through: 2.3.8
 
   undici-types@6.20.0: {}
-
-  uuid@11.1.0: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
gh actions setup will likely need to be changed entirely (ill try taking care of that before un-drafting) because i don't think buildah supports modern dockerfile features (podman users can still build it with a separate buildkit container).

keeps devDependencies out from the final image, which reduces image size quite a bit if used correctly. the "dev dependencies" name is also a bit of a misnomer since frontend dependencies *seem* to be bundled by vite as well, meaning they should also be specified in devDependencies (& don't need to be in the image)

not fully decided on alpine just yet, keeping the `slim` image may be a better idea for a few reasons, and would still get quite a few space savings from the rest of the changes

did some simple testing and the image seems to work Fine

```
REPOSITORY                  TAG       IMAGE ID       CREATED          SIZE
localhost/kopper/ask-js     latest    43191bb9eebc   52 seconds ago   213MB
ghcr.io/ihateblueb/ask-js   dev       699a4c93afa6   4 minutes ago    576MB
```