### PR TITLE
fix: multi-line asks only having first line quoted

### DIFF
--- a/packages/frontend/src/lib/components/AskAndResponse.svelte
+++ b/packages/frontend/src/lib/components/AskAndResponse.svelte
@@ -24,7 +24,7 @@
 	let deleted = $state(false);
 
 	function copyAsk() {
-		navigator.clipboard.writeText(`> ${data.content}
+		navigator.clipboard.writeText(`> ${data.content.replaceAll("\n", "\n> ")}
 
 ${submittedResponse ? response : data.response}
 


### PR DESCRIPTION
Adds a quote marker to the start of every line of an ask when copying it. Fixes #10.